### PR TITLE
Add Phala archive

### DIFF
--- a/archives.json
+++ b/archives.json
@@ -169,6 +169,20 @@
       "genesisHash": "0xd2a620c27ec5cbc5621ff9a522689895074f7cca0d08e7134a7804e1a3ba86fc"
     },
     {
+      "network": "hydradx",
+      "providers": [
+        {
+          "provider": "subsquid",
+          "dataSourceUrl": "https://hydradx.archive.subsquid.io/graphql",
+          "explorerUrl": "https://hydradx.explorer.subsquid.io/graphql",
+          "release": "FireSquid",
+          "image": "substrate-ingest",
+          "gateway": "archive-gateway"
+        }
+      ],
+      "genesisHash": "0xafdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d"
+    },
+    {
       "network": "subsocial-solochain",
       "genesisHash": "0x0bd72c1c305172e1275278aaeb3f161e02eccb7a819e63f62d47bd53a28189f8",
       "providers": [

--- a/networks.json
+++ b/networks.json
@@ -109,6 +109,16 @@
       "genesisHash": "0xa3d114c2b8d0627c1aa9b134eafcf7d05ca561fdc19fb388bb9457f81809fb23"
     },
     {
+      "name": "hydradx-snakenet",
+      "displayName": "HydraDX Snakenet",
+      "tokens": [
+        "HDX"
+      ],
+      "website": "https://hydradx.io",
+      "description": "HydraDX is built as a parachain – specialized blockchain in the Polkadot network. It is benefiting from shared security, speed and flexibility of the Substrate framework while remaining optimized for a single purpose: enabling fluid programmable value exchange.",
+      "genesisHash": "0xd2a620c27ec5cbc5621ff9a522689895074f7cca0d08e7134a7804e1a3ba86fc"
+    },
+    {
       "name": "hydradx",
       "displayName": "HydraDX",
       "tokens": [
@@ -118,7 +128,7 @@
       "description": "HydraDX is built as a parachain – specialized blockchain in the Polkadot network. It is benefiting from shared security, speed and flexibility of the Substrate framework while remaining optimized for a single purpose: enabling fluid programmable value exchange.",
       "relayChain": "polkadot",
       "parachainId": "2034",
-      "genesisHash": "0xd2a620c27ec5cbc5621ff9a522689895074f7cca0d08e7134a7804e1a3ba86fc"
+      "genesisHash": "0xafdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d"
     },
     {
       "name": "darwinia",

--- a/registry.json
+++ b/registry.json
@@ -1,5 +1,5 @@
 {
-    "_comment": "This file is deprecated in favour of achives.json. It is left in the repository for backward compatibility of some tools",
+    "_comment": "This file is deprecated in favour of archives.json. It is left in the repository for backward compatibility of some tools",
     "archives": [
         {
             "network": "calamari",

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -4,6 +4,6 @@
 // Run npm run gen-types to generate this file from archives.
 //
 
-export type KnownArchives = "equilibrium"|"moonbeam"|"acala"|"kusama"|"polkadot"|"karura"|"crust"|"bifrost"|"moonriver"|"astar"|"shibuya"|"hydradx-snakenet"|"subsocial-solochain"|"quartz"|"moonbase"|"phala"
+export type KnownArchives = "equilibrium"|"moonbeam"|"acala"|"kusama"|"polkadot"|"karura"|"crust"|"bifrost"|"moonriver"|"astar"|"shibuya"|"hydradx-snakenet"|"subsocial-solochain"|"quartz"|"moonbase"|"phala"|"hydradx"
 export type KnownArchivesV5 = "calamari"|"pioneer"|"statemint"|"parallel"|"moonbeam"|"clover"|"nodle"|"quartz"|"heiko"|"kintsugi"|"basilisk"|"altair"|"acala"|"kusama"|"polkadot"|"karura"|"crust"|"bifrost"|"statemine"|"khala"|"kilt"|"moonriver"|"astar"|"shiden"|"hydradx"|"robonomics"|"subsocial"|"moonbase"
 


### PR DESCRIPTION
Add the Phala archive into types and descriptions. Fix typo.

Perhaps there is a need for a change in [networks.json](https://github.com/subsquid/archive-registry/blob/main/networks.json#L112) due to the existence of several variants of HydraDX chains.