### PR TITLE
Update type for LookupOptionsSubstrate to allow ArrowSquid

### DIFF
--- a/src/lookup.ts
+++ b/src/lookup.ts
@@ -33,7 +33,7 @@ export interface LookupOptionsSubstrate {
     /**
      * Archive release
      */
-    release?: 'FireSquid'
+    release?: 'FireSquid' | 'ArrowSquid'
 }
 
 export interface LookupOptionsEVM {


### PR DESCRIPTION
With TS the following wouldn't build:
```ts
  lookupArchive(env.archiveName as KnownArchivesSubstrate, {
    release: 'ArrowSquid',
    genesis: env.genesis,
    type: 'Substrate'
  })
```

> Type '"Substrate"' is not assignable to type '"EVM"'