### PR TITLE
ArrowSquid by default on Substrate

### DIFF
--- a/src/lookup.ts
+++ b/src/lookup.ts
@@ -103,7 +103,7 @@ Please consider submitting a PR to subsquid/archive-registry github repo to exte
     switch (opts.type) {
         case 'Substrate':
             return lookupInSubstrateRegistry(network, registrySubstrate, {
-                release: 'FireSquid',
+                release: 'ArrowSquid',
                 ...opts,
             })[0].dataSourceUrl
         case 'EVM':


### PR DESCRIPTION
There are lots of useless `{release: 'ArrowSquid'}` clauses in Substrate archives lookup commands. This makes them unnecessary.